### PR TITLE
Add UTF-8 BOM identifier to files lacking it

### DIFF
--- a/image_translations/skill_descriptions.csv
+++ b/image_translations/skill_descriptions.csv
@@ -1,4 +1,4 @@
-Move Name,Notes,Initial,Checked,Localized
+﻿Move Name,Notes,Initial,Checked,Localized
 ,,,,
 はむパンチ,,,,
 暴れ娘,,,,

--- a/image_translations/skill_names.csv
+++ b/image_translations/skill_names.csv
@@ -1,4 +1,4 @@
-Original,Notes,Initial,Checked,Localized
+﻿Original,Notes,Initial,Checked,Localized
 ,,,,
 はむパンチ,,Hamu-Punch,,
 暴れ娘,,Raging Girl,,


### PR DESCRIPTION
I noticed that some of the CSVs in the image translation folder weren't opening properly in Excel. After some research, I discovered that Excel needs a BOM to recognize the file as being UTF-8. Two of the four files were lacking it so I used Notepad++ to add it.